### PR TITLE
Upgrade pyo3 to 0.24

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -422,9 +422,9 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "heck"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -938,15 +938,15 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.20.3"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53bdbb96d49157e65d45cc287af5f32ffadd5f4761438b527b055fb0d4bb8233"
+checksum = "e5203598f366b11a02b13aa20cab591229ff0a89fd121a308a5df751d5fc9219"
 dependencies = [
  "cfg-if",
  "indoc",
  "libc",
  "memoffset",
- "parking_lot",
+ "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
@@ -955,10 +955,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "pyo3-asyncio"
-version = "0.20.0"
+name = "pyo3-async-runtimes"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea6b68e93db3622f3bb3bf363246cf948ed5375afe7abff98ccbdd50b184995"
+checksum = "dd0b83dc42f9d41f50d38180dad65f0c99763b65a3ff2a81bf351dd35a1df8bf"
 dependencies = [
  "futures",
  "once_cell",
@@ -969,9 +969,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.20.3"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deaa5745de3f5231ce10517a1f5dd97d53e5a2fd77aa6b5842292085831d48d7"
+checksum = "99636d423fa2ca130fa5acde3059308006d46f98caac629418e53f7ebb1e9999"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -979,9 +979,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.20.3"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b42531d03e08d4ef1f6e85a2ed422eb678b8cd62b762e53891c05faf0d4afa"
+checksum = "78f9cf92ba9c409279bc3305b5409d90db2d2c22392d443a87df3a1adad59e33"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -989,9 +989,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.20.3"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7305c720fa01b8055ec95e484a6eca7a83c841267f0dd5280f0c8b8551d2c158"
+checksum = "0b999cb1a6ce21f9a6b147dcf1be9ffedf02e0043aec74dc390f3007047cecd9"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -1001,9 +1001,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.20.3"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c7e9b68bb9c3149c5b0cade5d07f953d6d125eb4337723c4ccdb665f1f96185"
+checksum = "822ece1c7e1012745607d5cf0bcb2874769f0f7cb34c4cde03b9358eb9ef911a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1014,7 +1014,7 @@ dependencies = [
 
 [[package]]
 name = "pyo3-opentelemetry"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -1035,7 +1035,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
  "pyo3",
- "pyo3-asyncio",
+ "pyo3-async-runtimes",
  "pyo3-build-config",
  "pyo3-opentelemetry",
  "pyo3-tracing-subscriber",
@@ -1046,7 +1046,7 @@ dependencies = [
 
 [[package]]
 name = "pyo3-opentelemetry-macros"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1056,7 +1056,7 @@ dependencies = [
 
 [[package]]
 name = "pyo3-tracing-subscriber"
-version = "0.1.4"
+version = "0.2.0"
 dependencies = [
  "futures-core",
  "handlebars",
@@ -1065,7 +1065,7 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "pyo3",
- "pyo3-asyncio",
+ "pyo3-async-runtimes",
  "rstest",
  "serde",
  "serde_json",
@@ -1455,9 +1455,9 @@ checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.14"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1fc403891a21bcfb7c37834ba66a547a8f402146eba7265b5a6d88059c9ff2f"
+checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
 
 [[package]]
 name = "thiserror"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,9 @@ serde = { version = "1.0.145", features = ["derive"] }
 # * opentelemetry-proto
 opentelemetry = "0.27.1"
 opentelemetry_sdk = "0.27.1"
-pyo3 = { version = "0.20.0", features = ["macros"] }
-pyo3-asyncio = { version = "0.20.0", features = ["tokio-runtime"] }
-pyo3-build-config = "0.20.0"
+pyo3 = { version = "0.24.0", features = ["macros"] }
+pyo3-async-runtimes = { version = "0.24.0", features = ["tokio-runtime"] }
+pyo3-build-config = "0.24.0"
 rstest = "0.17.0"
 tokio = { version = "1.36.0", features = [] }
 tracing = { version = "0.1.41", features = ["log"] }

--- a/crates/opentelemetry-macros/src/lib.rs
+++ b/crates/opentelemetry-macros/src/lib.rs
@@ -259,7 +259,7 @@ fn get_python_parameter_name(signature: &Signature) -> syn::Result<proc_macro2::
             signature.inputs.iter().nth(1).ok_or_else(|| {
                 syn::Error::new(signature.__span(), ERROR_SIGNATURE_MUST_INCLUDE_PY)
             })?;
-    };
+    }
 
     match first_arg {
         syn::FnArg::Typed(arg) => Ok(arg.pat.to_token_stream()),
@@ -394,7 +394,7 @@ pub fn pypropagate(attr: TokenStream, item: TokenStream) -> TokenStream {
         } else {
             let config_parser = syn::meta::parser(|meta| config.add_nested_meta_item_fn(&meta));
             parse_macro_input!(attr with config_parser);
-        };
+        }
     }
 
     pypropagate_impl(item, &config).map_or_else(

--- a/crates/opentelemetry/src/lib.rs
+++ b/crates/opentelemetry/src/lib.rs
@@ -85,7 +85,7 @@
 //! }
 //!
 //! #[pymodule]
-//! fn my_module(_py: Python, m: &PyModule) -> PyResult<()> {
+//! fn my_module(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
 //!    m.add_function(wrap_pyfunction!(my_function, m)?)?;
 //!    Ok(())
 //! }
@@ -183,8 +183,8 @@ pub fn attach_otel_context_from_python(py: Python<'_>) -> PyResult<opentelemetry
 
     let current_context = get_current_context.call0()?;
     let data = pyo3::types::PyDict::new(py);
-    let kwargs = [("context", current_context), ("carrier", data)].into_py_dict(py);
-    inject.call((), Some(kwargs))?;
+    let kwargs = [("context", &current_context), ("carrier", data.as_any())].into_py_dict(py)?;
+    inject.call((), Some(&kwargs))?;
 
     let data: HashMap<String, String> = data.extract()?;
     let carrier: Carrier = data.into();

--- a/crates/tracing-subscriber/Cargo.toml
+++ b/crates/tracing-subscriber/Cargo.toml
@@ -19,7 +19,7 @@ opentelemetry = { workspace = true }
 opentelemetry-otlp = { version = "0.27.0", features = ["grpc-tonic", "trace", "tls-roots"], optional = true }
 opentelemetry-proto = { version = "0.27.0", optional = true, features = ["tonic"] }
 opentelemetry_sdk = { workspace = true, features = ["rt-tokio", "rt-tokio-current-thread"] }
-pyo3-asyncio = { workspace = true, features = ["tokio-runtime"], optional = true }
+pyo3-async-runtimes = { workspace = true, features = ["tokio-runtime"], optional = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
@@ -34,7 +34,7 @@ serde_json = "1.0.128"
 layer-otel-otlp = ["layer-otel-otlp-file", "dep:tonic"]
 layer-otel-otlp-file = ["dep:opentelemetry-otlp", "dep:opentelemetry-proto"]
 stubs = ["dep:handlebars"]
-pyo3 = ["dep:pyo3", "dep:pyo3-asyncio"]
+pyo3 = ["dep:pyo3", "dep:pyo3-async-runtimes"]
 extension-module = ["pyo3", "pyo3/extension-module"]
 default = ["extension-module"]
 

--- a/crates/tracing-subscriber/assets/python_stubs/__init__.pyi
+++ b/crates/tracing-subscriber/assets/python_stubs/__init__.pyi
@@ -74,7 +74,7 @@ class CurrentThreadTracingConfig:
     manager may be initialized multiple times for the same process with this configuration (although
     they should not be nested).
 
-    Note, this configuration is currently incompatible with async methods defined with `pyo3_asyncio`.
+    Note, this configuration is currently incompatible with async methods defined with `pyo3_async_runtimes`.
     """
 
     def __new__(cls, *, export_process: "ExportConfig") -> "CurrentThreadTracingConfig": ...

--- a/crates/tracing-subscriber/src/common.rs
+++ b/crates/tracing-subscriber/src/common.rs
@@ -19,7 +19,7 @@ macro_rules! create_init_submodule {
         $(funcs: [ $($func: path),+ ],)?
         $(submodules: [ $($mod_name: literal: $init_submod: path),+ ],)?
     ) => {
-        pub(crate) fn init_submodule(_name: &str, _py: pyo3::Python, m: &pyo3::types::PyModule) -> pyo3::PyResult<()> {
+        pub(crate) fn init_submodule(_name: &str, _py: pyo3::Python, m: &pyo3::Bound<'_, pyo3::types::PyModule>) -> pyo3::PyResult<()> {
             $($(
             m.add_class::<$class>()?;
             )+)?
@@ -37,9 +37,9 @@ macro_rules! create_init_submodule {
                 $(
                 let qualified_name = format!("{}.{}", _name, $mod_name);
                 let submod = pyo3::types::PyModule::new(_py, &qualified_name)?;
-                $init_submod(&qualified_name, _py, submod)?;
-                m.add($mod_name, submod)?;
-                modules.set_item(&qualified_name, submod)?;
+                $init_submod(&qualified_name, _py, &submod)?;
+                m.add($mod_name, &submod)?;
+                modules.set_item(&qualified_name, &submod)?;
                 )+
             )?
             Ok(())

--- a/crates/tracing-subscriber/src/layers/mod.rs
+++ b/crates/tracing-subscriber/src/layers/mod.rs
@@ -182,31 +182,31 @@ impl Config for PyConfig {
 
 /// Adds `layers` submodule to the root level submodule.
 #[allow(dead_code)]
-pub(crate) fn init_submodule(name: &str, py: Python, m: &PyModule) -> PyResult<()> {
+pub(crate) fn init_submodule(name: &str, py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     let modules = py.import("sys")?.getattr("modules")?;
 
     #[cfg(feature = "layer-otel-otlp-file")]
     {
         let submod = pyo3::types::PyModule::new(py, "otel_otlp_file")?;
         let qualified_name = format!("{name}.otel_otlp_file");
-        otel_otlp_file::init_submodule(qualified_name.as_str(), py, submod)?;
-        modules.set_item(qualified_name, submod)?;
-        m.add_submodule(submod)?;
+        otel_otlp_file::init_submodule(qualified_name.as_str(), py, &submod)?;
+        modules.set_item(qualified_name, &submod)?;
+        m.add_submodule(&submod)?;
     }
     #[cfg(feature = "layer-otel-otlp")]
     {
         let submod = pyo3::types::PyModule::new(py, "otel_otlp")?;
         let qualified_name = format!("{name}.otel_otlp");
-        otel_otlp::init_submodule(qualified_name.as_str(), py, submod)?;
-        modules.set_item(qualified_name, submod)?;
-        m.add_submodule(submod)?;
+        otel_otlp::init_submodule(qualified_name.as_str(), py, &submod)?;
+        modules.set_item(qualified_name, &submod)?;
+        m.add_submodule(&submod)?;
     }
 
     let submod = pyo3::types::PyModule::new(py, "file")?;
     let qualified_name = format!("{name}.file");
-    fmt_file::init_submodule(qualified_name.as_str(), py, submod)?;
-    modules.set_item(qualified_name, submod)?;
-    m.add_submodule(submod)?;
+    fmt_file::init_submodule(qualified_name.as_str(), py, &submod)?;
+    modules.set_item(qualified_name, &submod)?;
+    m.add_submodule(&submod)?;
 
     Ok(())
 }

--- a/crates/tracing-subscriber/src/layers/otel_otlp.rs
+++ b/crates/tracing-subscriber/src/layers/otel_otlp.rs
@@ -259,8 +259,8 @@ impl PyConfig {
     fn new(
         span_limits: Option<PySpanLimits>,
         resource: Option<PyResource>,
-        metadata_map: Option<&PyAny>,
-        sampler: Option<&PyAny>,
+        metadata_map: Option<&Bound<'_, PyAny>>,
+        sampler: Option<&Bound<'_, PyAny>>,
         endpoint: Option<&str>,
         timeout_millis: Option<u64>,
         pre_shutdown_timeout_millis: u64,
@@ -270,8 +270,8 @@ impl PyConfig {
         Ok(Self {
             span_limits: span_limits.unwrap_or_default(),
             resource: resource.unwrap_or_default(),
-            metadata_map: metadata_map.map(PyAny::extract).transpose()?,
-            sampler: sampler.map(PyAny::extract).transpose()?.unwrap_or_default(),
+            metadata_map: metadata_map.map(pyo3::types::PyAnyMethods::extract).transpose()?,
+            sampler: sampler.map(pyo3::types::PyAnyMethods::extract).transpose()?.unwrap_or_default(),
             endpoint: endpoint.map(String::from),
             timeout_millis,
             pre_shutdown_timeout_millis,

--- a/crates/tracing-subscriber/src/lib.rs
+++ b/crates/tracing-subscriber/src/lib.rs
@@ -89,7 +89,7 @@
 //! const TRACING_SUBSCRIBER_SUBMODULE_NAME: &str = "tracing_subscriber";
 //!
 //! #[pymodule]
-//! fn example(py: Python, m: &PyModule) -> PyResult<()> {
+//! fn example(py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
 //!     // add your functions, modules, and classes
 //!     pyo3_tracing_subscriber::add_submodule(
 //!         MY_PACKAGE_NAME,
@@ -123,7 +123,7 @@
 //!
 //! * `pyo3-opentelemetry` - propagates `OpenTelemetry` contexts from Python into Rust.
 #[cfg(feature = "pyo3")]
-use pyo3::{types::PyModule, PyResult, Python};
+use pyo3::{types::PyModule, types::PyAnyMethods, types::PyModuleMethods, Bound, PyResult, Python};
 
 #[cfg(feature = "pyo3")]
 use self::{
@@ -223,13 +223,13 @@ pub fn add_submodule(
     fully_qualified_namespace: &str,
     name: &str,
     py: Python,
-    parent_module: &PyModule,
+    parent_module: &Bound<'_, PyModule>,
 ) -> PyResult<()> {
     let tracing_subscriber = PyModule::new(py, name)?;
     let fully_qualified_name = format!("{fully_qualified_namespace}.{name}");
-    init_submodule(&fully_qualified_name, py, tracing_subscriber)?;
+    init_submodule(&fully_qualified_name, py, &tracing_subscriber)?;
     let modules = py.import("sys")?.getattr("modules")?;
-    modules.set_item(fully_qualified_name, tracing_subscriber)?;
-    parent_module.add_submodule(tracing_subscriber)?;
+    modules.set_item(fully_qualified_name, &tracing_subscriber)?;
+    parent_module.add_submodule(&tracing_subscriber)?;
     Ok(())
 }

--- a/examples/pyo3-opentelemetry-lib/Cargo.toml
+++ b/examples/pyo3-opentelemetry-lib/Cargo.toml
@@ -21,7 +21,7 @@ crate-type =  ["cdylib", "rlib"]
 opentelemetry = { workspace = true }
 opentelemetry_sdk = { workspace = true }
 pyo3 = { workspace = true }
-pyo3-asyncio = { workspace = true, features = ["tokio", "tokio-runtime"] }
+pyo3-async-runtimes = { workspace = true, features = ["tokio", "tokio-runtime"] }
 pyo3-opentelemetry = { path = "../../crates/opentelemetry" }
 pyo3-tracing-subscriber = { path = "../../crates/tracing-subscriber", features = ["layer-otel-otlp-file", "layer-otel-otlp"] }
 tokio = { version = "1.27.0", features = ["sync", "parking_lot", "macros"] }

--- a/examples/pyo3-opentelemetry-lib/pyo3_opentelemetry_lib/_tracing_subscriber/__init__.pyi
+++ b/examples/pyo3-opentelemetry-lib/pyo3_opentelemetry_lib/_tracing_subscriber/__init__.pyi
@@ -74,7 +74,7 @@ class CurrentThreadTracingConfig:
     manager may be initialized multiple times for the same process with this configuration (although
     they should not be nested).
 
-    Note, this configuration is currently incompatible with async methods defined with `pyo3_asyncio`.
+    Note, this configuration is currently incompatible with async methods defined with `pyo3_async_runtimes`.
     """
 
     def __new__(cls, *, export_process: "ExportConfig") -> "CurrentThreadTracingConfig": ...

--- a/examples/pyo3-opentelemetry-lib/src/lib.rs
+++ b/examples/pyo3-opentelemetry-lib/src/lib.rs
@@ -93,8 +93,8 @@ pub fn example_function(py: Python<'_>) -> HashMap<String, String> {
 /// HashMap with the propagated OTel context.
 #[pypropagate]
 #[pyfunction]
-pub fn example_function_async<'a>(py: Python<'a>) -> PyResult<&'a PyAny> {
-    pyo3_asyncio::tokio::future_into_py(py, example_function_impl_async().with_current_context())
+pub fn example_function_async<'a>(py: Python<'a>) -> PyResult<Bound<'a, PyAny>> {
+    pyo3_async_runtimes::tokio::future_into_py(py, example_function_impl_async().with_current_context())
 }
 
 /// An example pyclass sturct that will have methods that propagate their OTel contexts from
@@ -119,8 +119,8 @@ impl ExampleStruct {
 
     /// An example async struct method that will call a function containing and span and returns a
     /// HashMap with the propagated OTel context.
-    pub fn example_method_async<'a>(&self, py: Python<'a>) -> PyResult<&'a PyAny> {
-        pyo3_asyncio::tokio::future_into_py(
+    pub fn example_method_async<'a>(&self, py: Python<'a>) -> PyResult<Bound<'a, PyAny>> {
+        pyo3_async_runtimes::tokio::future_into_py(
             py,
             example_function_impl_async().with_current_context(),
         )
@@ -128,7 +128,7 @@ impl ExampleStruct {
 }
 
 #[pymodule]
-fn pyo3_opentelemetry_lib(py: Python, m: &PyModule) -> PyResult<()> {
+fn pyo3_opentelemetry_lib(py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<ExampleStruct>()?;
     m.add_function(wrap_pyfunction!(example_function, m)?)?;
     m.add_function(wrap_pyfunction!(example_function_async, m)?)?;


### PR DESCRIPTION
I currently have a project that uses `pyo3 = 0.24` and noticed that pyo3-opentelemetry is not compatible with that version of pyo3. This PR upgrades pyo3 to 0.24 and also replaces pyo3-asyncio with [pyo3-async-runtimes](https://github.com/PyO3/pyo3-async-runtimes). The latter crate is considered the "official" replacement for the mostly abandoned `pyo3-asyncio`, is maintained by the same developers as pyo3 itself and supports `pyo3` past `0.20.`